### PR TITLE
Fixed erroneous message about missing representation

### DIFF
--- a/subprojects/store/src/main/java/tools/refinery/store/model/internal/ModelImpl.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/model/internal/ModelImpl.java
@@ -33,7 +33,7 @@ public class ModelImpl implements Model {
 		if (maps.containsKey(representation)) {
 			return (VersionedMap<K, V>) maps.get(representation);
 		} else {
-			throw new IllegalArgumentException("Model does have representation " + representation);
+			throw new IllegalArgumentException("Model does not have representation " + representation);
 		}
 	}
 


### PR DESCRIPTION
"Model does have representation" is misleading because the problem is about the model **not** containing the representation. This PR adds the missing "not" word.