### PR TITLE
Fixed some documentation typos

### DIFF
--- a/subprojects/docs/src/docs/learn/language/classes/index.md
+++ b/subprojects/docs/src/docs/learn/language/classes/index.md
@@ -36,7 +36,7 @@ import NewObjectsSimple from './NewObjectsSimple.svg';
 
 As you can see, no new objects represent potential nodes that are instanceof of both `Region` and `State`.
 In fact, such instances are not permitted at all.
-Each node must the instance of a _single most-specific class:_
+Each node must be the instance of a _single most-specific class:_
 
 import InvalidInstance from './InvalidInstance.svg';
 

--- a/subprojects/docs/src/docs/learn/language/logic/index.md
+++ b/subprojects/docs/src/docs/learn/language/logic/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Partial modeling
 
-Refinery allow precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
+Refinery allows precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
 During model generation, unknown aspects of the partial model get _refined_ into concrete (true or false) facts until the generated model is completed, or a contradiction is reached.
 
 The _Belnap--Dunn four-valued logic_ supports the following truth values:
@@ -15,7 +15,7 @@ The _Belnap--Dunn four-valued logic_ supports the following truth values:
 * `true` values correspond to facts known about the model, e.g., that a node is the instance of a given class or there is a reference between two nodes.
 * `false` values correspond to facts that are known not to hold, e.g., that a node is _not_ an instance of a given class or there is _no_ reference between two nodes.
 * `unknown` values express uncertain properties and design decisions yet to be made. During model refinement, `unknown` values are gradually replaced with `true` and `false` values until a consistent and concrete model is derived.
-* `error` values represent contradictions and validation failures in the model. One a model contains an error value, it can't be refined into a consistent model anymore.
+* `error` values represent contradictions and validation failures in the model. Once a model contains an error value, it can't be refined into a consistent model anymore.
 
 ## Assertions
 
@@ -91,7 +91,7 @@ import AssertionsError from './AssertionsError.svg';
 
 ### Default assertions
 
-Assertions marked with the `default` keyword have _lower priority_ that other assertions.
+Assertions marked with the `default` keyword have _lower priority_ than other assertions.
 They may contain wildcard arguments `*` to specify information about _all_ nodes in the graph.
 However, they can be overridden by more specific assertions that are not marked with the `default` keyword.
 
@@ -180,7 +180,7 @@ multi removableMulti.
 
 ## Type scopes
 
-_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) that `exists` or `equals` assertions.
+_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) than `exists` or `equals` assertions.
 
 A _type scope constraint_ is formed by a unary symbol (a [class](../classes/#classes) or a [predicate](../predicates) with a single parameter) and _scope range._
 Ranges have a form similar to [multiplicity constraints](../classes#multiplicity): a range `n..m` indicates a lower bound of `n` and an upper bound of `m`.
@@ -243,7 +243,7 @@ import StrongerObjectScopes from './StrongerObjectScopes.svg';
 ### Incremental scopes
 
 We may specify an _incremental_ object scope with the `+=` operator to determine the number of new instances to be added to the model.
-This is only allowed for symbol that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
+This is only allowed for symbols that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
 
 For example, to ensure that between 5 and 7 `State` instances are added to the model, we may write:
 

--- a/subprojects/docs/src/docs/learn/language/predicates/index.md
+++ b/subprojects/docs/src/docs/learn/language/predicates/index.md
@@ -141,7 +141,7 @@ pred regionWithoutEntry(Region r) <->
 ```
 
 In a graph predicate, all parameter variables must be _positively bound,_ i.e., appear in at least one positive literal (atom).
-Negative literals may further constrain the predicate match one it has been established by the positive literals.
+Negative literals may further constrain the predicate match once it has been established by the positive literals.
 
 ## Object equality
 
@@ -198,7 +198,7 @@ pred regionWithInvalidNumberOfEntries(r) <->
 
 Graph predicates may act as _derived types_ and _references_ in metamodel.
 
-A graph predicate with exactly 1 parameters can be use as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
+A graph predicate with exactly 1 parameter can be used as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
 
 _Derived references_ are graph predicates with exactly 2 parameters, which correspond the source and target node of the reference.
 

--- a/subprojects/docs/src/docs/learn/tutorials/file-system/index.md
+++ b/subprojects/docs/src/docs/learn/tutorials/file-system/index.md
@@ -44,7 +44,7 @@ If you click it now, it'll take you to the [Refinery web UI](#refinery-web-ui).
 
 ### Metamodel constraints
 
-Our specification not only lists the concepts (classes and relations) of [file system](#describing-domain-concepts) the domain, but also prescribes a set of **metamodel constraints** concisely.
+Our specification not only lists the concepts (classes and relations) of the [file system](#describing-domain-concepts) domain, but also prescribes a set of **metamodel constraints** concisely.
 
 :::info
 

--- a/subprojects/docs/versioned_docs/version-0.1.0/learn/language/classes/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.0/learn/language/classes/index.md
@@ -36,7 +36,7 @@ import NewObjectsSimple from './NewObjectsSimple.svg';
 
 As you can see, no new objects represent potential nodes that are instanceof of both `Region` and `State`.
 In fact, such instances are not permitted at all.
-Each node must the instance of a _single most-specific class:_
+Each node must be the instance of a _single most-specific class:_
 
 import InvalidInstance from './InvalidInstance.svg';
 

--- a/subprojects/docs/versioned_docs/version-0.1.0/learn/language/logic/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.0/learn/language/logic/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Partial modeling
 
-Refinery allow precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
+Refinery allows precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
 During model generation, unknown aspects of the partial model get _refined_ into concrete (true or false) facts until the generated model is completed, or a contradiction is reached.
 
 The _Belnap--Dunn four-valued logic_ supports the following truth values:
@@ -15,7 +15,7 @@ The _Belnap--Dunn four-valued logic_ supports the following truth values:
 * `true` values correspond to facts known about the model, e.g., that a node is the instance of a given class or there is a reference between two nodes.
 * `false` values correspond to facts that are known not to hold, e.g., that a node is _not_ an instance of a given class or there is _no_ reference between two nodes.
 * `unknown` values express uncertain properties and design decisions yet to be made. During model refinement, `unknown` values are gradually replaced with `true` and `false` values until a consistent and concrete model is derived.
-* `error` values represent contradictions and validation failures in the model. One a model contains an error value, it can't be refined into a consistent model anymore.
+* `error` values represent contradictions and validation failures in the model. Once a model contains an error value, it can't be refined into a consistent model anymore.
 
 ## Assertions
 
@@ -91,7 +91,7 @@ import AssertionsError from './AssertionsError.svg';
 
 ### Default assertions
 
-Assertions marked with the `default` keyword have _lower priority_ that other assertions.
+Assertions marked with the `default` keyword have _lower priority_ than other assertions.
 They may contain wildcard arguments `*` to specify information about _all_ nodes in the graph.
 However, they can be overridden by more specific assertions that are not marked with the `default` keyword.
 
@@ -180,7 +180,7 @@ multi removableMulti.
 
 ## Type scopes
 
-_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) that `exists` or `equals` assertions.
+_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) than `exists` or `equals` assertions.
 
 A _type scope constraint_ is formed by a unary symbol (a [class](../classes/#classes) or a [predicate](../predicates) with a single parameter) and _scope range._
 Ranges have a form similar to [multiplicity constraints](../classes#multiplicity): a range `n..m` indicates a lower bound of `n` and an upper bound of `m`.
@@ -243,7 +243,7 @@ import StrongerObjectScopes from './StrongerObjectScopes.svg';
 ### Incremental scopes
 
 We may specify an _incremental_ object scope with the `+=` operator to determine the number of new instances to be added to the model.
-This is only allowed for symbol that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
+This is only allowed for symbols that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
 
 For example, to ensure that between 5 and 7 `State` instances are added to the model, we may write:
 

--- a/subprojects/docs/versioned_docs/version-0.1.0/learn/language/predicates/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.0/learn/language/predicates/index.md
@@ -141,7 +141,7 @@ pred regionWithoutEntry(Region r) <->
 ```
 
 In a graph predicate, all parameter variables must be _positively bound,_ i.e., appear in at least one positive literal (atom).
-Negative literals may further constrain the predicate match one it has been established by the positive literals.
+Negative literals may further constrain the predicate match once it has been established by the positive literals.
 
 ## Object equality
 
@@ -198,7 +198,7 @@ pred regionWithInvalidNumberOfEntries(r) <->
 
 Graph predicates may act as _derived types_ and _references_ in metamodel.
 
-A graph predicate with exactly 1 parameters can be use as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
+A graph predicate with exactly 1 parameter can be used as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
 
 _Derived references_ are graph predicates with exactly 2 parameters, which correspond the source and target node of the reference.
 

--- a/subprojects/docs/versioned_docs/version-0.1.4/learn/language/classes/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.4/learn/language/classes/index.md
@@ -36,7 +36,7 @@ import NewObjectsSimple from './NewObjectsSimple.svg';
 
 As you can see, no new objects represent potential nodes that are instanceof of both `Region` and `State`.
 In fact, such instances are not permitted at all.
-Each node must the instance of a _single most-specific class:_
+Each node must be the instance of a _single most-specific class:_
 
 import InvalidInstance from './InvalidInstance.svg';
 

--- a/subprojects/docs/versioned_docs/version-0.1.4/learn/language/logic/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.4/learn/language/logic/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Partial modeling
 
-Refinery allow precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
+Refinery allows precisely expressing _unknown,_ _uncertain_ or even _contradictory_ information using [four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap).
 During model generation, unknown aspects of the partial model get _refined_ into concrete (true or false) facts until the generated model is completed, or a contradiction is reached.
 
 The _Belnap--Dunn four-valued logic_ supports the following truth values:
@@ -15,7 +15,7 @@ The _Belnap--Dunn four-valued logic_ supports the following truth values:
 * `true` values correspond to facts known about the model, e.g., that a node is the instance of a given class or there is a reference between two nodes.
 * `false` values correspond to facts that are known not to hold, e.g., that a node is _not_ an instance of a given class or there is _no_ reference between two nodes.
 * `unknown` values express uncertain properties and design decisions yet to be made. During model refinement, `unknown` values are gradually replaced with `true` and `false` values until a consistent and concrete model is derived.
-* `error` values represent contradictions and validation failures in the model. One a model contains an error value, it can't be refined into a consistent model anymore.
+* `error` values represent contradictions and validation failures in the model. Once a model contains an error value, it can't be refined into a consistent model anymore.
 
 ## Assertions
 
@@ -91,7 +91,7 @@ import AssertionsError from './AssertionsError.svg';
 
 ### Default assertions
 
-Assertions marked with the `default` keyword have _lower priority_ that other assertions.
+Assertions marked with the `default` keyword have _lower priority_ than other assertions.
 They may contain wildcard arguments `*` to specify information about _all_ nodes in the graph.
 However, they can be overridden by more specific assertions that are not marked with the `default` keyword.
 
@@ -180,7 +180,7 @@ multi removableMulti.
 
 ## Type scopes
 
-_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) that `exists` or `equals` assertions.
+_Type scopes_ offer finer-grained control over the number of graph nodes in the generated model (as represented by the multi-objects) than `exists` or `equals` assertions.
 
 A _type scope constraint_ is formed by a unary symbol (a [class](../classes/#classes) or a [predicate](../predicates) with a single parameter) and _scope range._
 Ranges have a form similar to [multiplicity constraints](../classes#multiplicity): a range `n..m` indicates a lower bound of `n` and an upper bound of `m`.
@@ -243,7 +243,7 @@ import StrongerObjectScopes from './StrongerObjectScopes.svg';
 ### Incremental scopes
 
 We may specify an _incremental_ object scope with the `+=` operator to determine the number of new instances to be added to the model.
-This is only allowed for symbol that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
+This is only allowed for symbols that are classes with no subclasses, as it directly influences the number of nodes represented by the corresponding `::new` object.
 
 For example, to ensure that between 5 and 7 `State` instances are added to the model, we may write:
 

--- a/subprojects/docs/versioned_docs/version-0.1.4/learn/language/predicates/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.4/learn/language/predicates/index.md
@@ -141,7 +141,7 @@ pred regionWithoutEntry(Region r) <->
 ```
 
 In a graph predicate, all parameter variables must be _positively bound,_ i.e., appear in at least one positive literal (atom).
-Negative literals may further constrain the predicate match one it has been established by the positive literals.
+Negative literals may further constrain the predicate match once it has been established by the positive literals.
 
 ## Object equality
 
@@ -198,7 +198,7 @@ pred regionWithInvalidNumberOfEntries(r) <->
 
 Graph predicates may act as _derived types_ and _references_ in metamodel.
 
-A graph predicate with exactly 1 parameters can be use as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
+A graph predicate with exactly 1 parameter can be used as if it was a class: you may use it as a [_parameter type_](#atoms) in other graph patterns, as a _target type_ of a (non-containment) [reference](../classes/#references), or in a [_scope constraint_](../logic#type-scopes).
 
 _Derived references_ are graph predicates with exactly 2 parameters, which correspond the source and target node of the reference.
 

--- a/subprojects/docs/versioned_docs/version-0.1.4/learn/tutorials/file-system/index.md
+++ b/subprojects/docs/versioned_docs/version-0.1.4/learn/tutorials/file-system/index.md
@@ -44,7 +44,7 @@ If you click it now, it'll take you to the [Refinery web UI](#refinery-web-ui).
 
 ### Metamodel constraints
 
-Our specification not only lists the concepts (classes and relations) of [file system](#describing-domain-concepts) the domain, but also prescribes a set of **metamodel constraints** concisely.
+Our specification not only lists the concepts (classes and relations) of the [file system](#describing-domain-concepts) domain, but also prescribes a set of **metamodel constraints** concisely.
 
 :::info
 


### PR DESCRIPTION
Fixed some typos in the documentation. I also found two other problems in `version-0.1.4/learn/language/logic/index.md` (probably also present in other versions) that I can't fix but I think they should be addressed:

line 26:
> A _negative_ assertion with a `false` truth value is indicated by prefixing it with `!`.

The double negation makes this a bit ambiguous. Maybe this would be better:

"A _negative_ assertion is one that is expected to have a `false` truth value. Such assertions are indicated by prefixing them with `!`."

line 137:
> In the Refinery web UI, `?exists(o)` is represented with a _dashed_ border, while `?equals(o, o)`

This sentence seems to be unfinished.
